### PR TITLE
Revert "TD-502: Enable usage of user_id and party_id from token (#26)"

### DIFF
--- a/apps/capi/src/capi_handler_utils.erl
+++ b/apps/capi/src/capi_handler_utils.erl
@@ -111,11 +111,15 @@ get_subject_id(Context) ->
 
 -spec get_user_id(processing_context()) -> binary().
 get_user_id(Context) ->
-    capi_auth:get_user_id(get_auth_context(Context)).
+    %% TODO Replace when user ids finally stop being equal to party ids
+    %% capi_auth:get_user_id(get_auth_context(Context)).
+    get_subject_id(Context).
 
 -spec get_party_id(processing_context()) -> binary().
 get_party_id(Context) ->
-    capi_auth:get_party_id(get_auth_context(Context)).
+    %% TODO Replace when user ids finally stop being equal to party ids
+    %% capi_auth:get_party_id(get_auth_context(Context)).
+    get_subject_id(Context).
 
 %% Utils
 

--- a/apps/capi/test/capi_ct_helper_token_keeper.erl
+++ b/apps/capi/test/capi_ct_helper_token_keeper.erl
@@ -173,15 +173,13 @@ combine_metadata(#{} = FullMetadata) ->
 
 user_session_metadata() ->
     genlib_map:compact(#{
-        ?TK_META_PARTY_ID => ?PARTY_ID,
         ?TK_META_USER_ID => ?USER_ID,
         ?TK_META_USER_EMAIL => ?USER_EMAIL
     }).
 
 api_key_metadata() ->
     genlib_map:compact(#{
-        ?TK_META_PARTY_ID => ?PARTY_ID,
-        ?TK_META_USER_ID => ?USER_ID
+        ?TK_META_PARTY_ID => ?PARTY_ID
     }).
 
 consumer_metadata(Consumer) ->


### PR DESCRIPTION
This reverts commit 2de9367561a511f0dc1448881201de48e9004c54.

Коммит по таске будет в отдельной `epic/` ветке.