### PR TITLE
TD-502: Enable usage of user_id and party_id from token (#26)

### DIFF
--- a/apps/capi/src/capi_handler_utils.erl
+++ b/apps/capi/src/capi_handler_utils.erl
@@ -111,15 +111,11 @@ get_subject_id(Context) ->
 
 -spec get_user_id(processing_context()) -> binary().
 get_user_id(Context) ->
-    %% TODO Replace when user ids finally stop being equal to party ids
-    %% capi_auth:get_user_id(get_auth_context(Context)).
-    get_subject_id(Context).
+    capi_auth:get_user_id(get_auth_context(Context)).
 
 -spec get_party_id(processing_context()) -> binary().
 get_party_id(Context) ->
-    %% TODO Replace when user ids finally stop being equal to party ids
-    %% capi_auth:get_party_id(get_auth_context(Context)).
-    get_subject_id(Context).
+    capi_auth:get_party_id(get_auth_context(Context)).
 
 %% Utils
 

--- a/apps/capi/test/capi_ct_helper_token_keeper.erl
+++ b/apps/capi/test/capi_ct_helper_token_keeper.erl
@@ -173,13 +173,15 @@ combine_metadata(#{} = FullMetadata) ->
 
 user_session_metadata() ->
     genlib_map:compact(#{
+        ?TK_META_PARTY_ID => ?PARTY_ID,
         ?TK_META_USER_ID => ?USER_ID,
         ?TK_META_USER_EMAIL => ?USER_EMAIL
     }).
 
 api_key_metadata() ->
     genlib_map:compact(#{
-        ?TK_META_PARTY_ID => ?PARTY_ID
+        ?TK_META_PARTY_ID => ?PARTY_ID,
+        ?TK_META_USER_ID => ?USER_ID
     }).
 
 consumer_metadata(Consumer) ->


### PR DESCRIPTION
* TD-502: Enable usage of user_id and party_id from token

* Fix tests

Вынесенные из мастера в эпик изменения https://github.com/valitydev/capi-v2/pull/27